### PR TITLE
Handle exceptions in sample

### DIFF
--- a/ext/rblineprof.c
+++ b/ext/rblineprof.c
@@ -245,9 +245,9 @@ lineprof_ensure(VALUE self)
 }
 
 static VALUE
-lineprof_rescue(VALUE args)
+lineprof_rescue(VALUE args, VALUE exception_object)
 {
-  rb_raise(rb_eRuntimeError, "Exception raised in profiled Ruby code");
+  rb_raise(rb_eRuntimeError, "Uncaught exception (%s) in profiled code.", rb_obj_classname(exception_object));
   return Qnil;
 }
 


### PR DESCRIPTION
Small wrapper over the `lineprof` function to raise a `RuntimeError` with an error message indicating that the sampled code threw an uncaught exception that got all the way here.
