### PR TITLE
Object Allocation Profiler

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -1,5 +1,7 @@
 require 'mkmf'
 
+have_func('rb_os_allocated_objects')
+
 if RUBY_VERSION >= "1.9"
   require "debugger/ruby_core_source"
 

--- a/ext/rblineprof.c
+++ b/ext/rblineprof.c
@@ -23,6 +23,10 @@
   typedef rb_event_t rb_event_flag_t;
 #endif
 
+#if defined(HAVE_RB_OS_ALLOCATED_OBJECTS) && defined(RUBY_VM)
+size_t rb_os_allocated_objects(void);
+#endif
+
 static VALUE gc_hook;
 
 /*
@@ -36,6 +40,9 @@ typedef uint64_t prof_time_t;
 typedef struct snapshot {
   prof_time_t wall_time;
   prof_time_t cpu_time;
+#ifdef HAVE_RB_OS_ALLOCATED_OBJECTS
+  size_t allocated_objects;
+#endif
 } snapshot_t;
 
 /*
@@ -155,6 +162,9 @@ snapshot_diff(snapshot_t *t1, snapshot_t *t2)
   snapshot_t diff = {
     .wall_time         = t1->wall_time - t2->wall_time,
     .cpu_time          = t1->cpu_time  - t2->cpu_time,
+#ifdef HAVE_RB_OS_ALLOCATED_OBJECTS
+    .allocated_objects = t1->allocated_objects - t2->allocated_objects
+#endif
   };
 
   return diff;
@@ -165,6 +175,9 @@ snapshot_increment(snapshot_t *s, snapshot_t *inc)
 {
   s->wall_time         += inc->wall_time;
   s->cpu_time          += inc->cpu_time;
+#ifdef HAVE_RB_OS_ALLOCATED_OBJECTS
+  s->allocated_objects += inc->allocated_objects;
+#endif
 }
 
 static inline void
@@ -350,6 +363,9 @@ profiler_hook(rb_event_flag_t event, NODE *node, VALUE self, ID mid, VALUE klass
   snapshot_t now = {
     .wall_time         = walltime_usec(),
     .cpu_time          = cputime_usec(),
+#ifdef HAVE_RB_OS_ALLOCATED_OBJECTS
+    .allocated_objects = rb_os_allocated_objects()
+#endif
   };
 
   switch (event) {
@@ -486,20 +502,36 @@ summarize_files(st_data_t key, st_data_t record, st_data_t arg)
   VALUE ary = rb_ary_new();
   long i;
 
-  rb_ary_store(ary, 0, rb_ary_new3(6,
+  rb_ary_store(ary, 0, rb_ary_new3(
+#ifdef HAVE_RB_OS_ALLOCATED_OBJECTS
+    7,
+#else
+    6,
+#endif
     ULL2NUM(srcfile->total.wall_time),
     ULL2NUM(srcfile->child.wall_time),
     ULL2NUM(srcfile->exclusive.wall_time),
     ULL2NUM(srcfile->total.cpu_time),
     ULL2NUM(srcfile->child.cpu_time),
     ULL2NUM(srcfile->exclusive.cpu_time)
+#ifdef HAVE_RB_OS_ALLOCATED_OBJECTS
+    , ULL2NUM(srcfile->total.allocated_objects)
+#endif
   ));
 
   for (i=1; i<srcfile->nlines; i++)
-    rb_ary_store(ary, i, rb_ary_new3(3,
+    rb_ary_store(ary, i, rb_ary_new3(
+#ifdef HAVE_RB_OS_ALLOCATED_OBJECTS
+      4,
+#else
+      3,
+#endif
       ULL2NUM(srcfile->lines[i].total.wall_time),
       ULL2NUM(srcfile->lines[i].total.cpu_time),
       ULL2NUM(srcfile->lines[i].calls)
+#ifdef HAVE_RB_OS_ALLOCATED_OBJECTS
+      , ULL2NUM(srcfile->lines[i].total.allocated_objects)
+#endif
     ));
   rb_hash_aset(ret, rb_str_new2(srcfile->filename), ary);
 

--- a/test.rb
+++ b/test.rb
@@ -92,10 +92,27 @@ file = RUBY_VERSION > '1.9' ? File.expand_path(__FILE__) : __FILE__
 # profile = lineprof(file) do
 profile = lineprof(/./) do
   outer
+
+  100.times{ 1 }
+  100.times{ 1 + 1 }
+  100.times{ 1.1 }
+  100.times{ 1.1 + 1 }
+  100.times{ 1.1 + 1.1 }
+  100.times{ "str" }
+  ('a'..'z').to_a
 end
 
 File.readlines(file).each_with_index do |line, num|
-  wall, cpu, calls = profile[file][num+1]
+  wall, cpu, calls, allocations = profile[file][num+1]
+
+  if allocations > 0
+    printf "% 10d objs | %s", allocations, line
+  else
+    printf "                | %s", line
+  end
+
+  next
+
   if calls && calls > 0
     printf "% 8.1fms + % 8.1fms (% 5d) | %s", cpu/1000.0, (wall-cpu)/1000.0, calls, line
     # printf "% 8.1fms (% 5d) | %s", wall/1000.0, calls, line
@@ -107,7 +124,7 @@ end
 
 puts
 profile.each do |file, data|
-  total, child, exclusive = data[0]
+  total, child, exclusive, allocations = data[0]
   puts file
   printf "  % 10.1fms in this file\n", exclusive/1000.0
   printf "  % 10.1fms in this file + children\n", total/1000.0


### PR DESCRIPTION
Requires a patched ruby that exposes `size_t rb_os_allocated_objects(void)`.

REE:

```
       100 objs |   100.times{ 1 }
       100 objs |   100.times{ 1 + 1 }
       100 objs |   100.times{ 1.1 }
       200 objs |   100.times{ 1.1 + 1 }
       200 objs |   100.times{ 1.1 + 1.1 }
       200 objs |   100.times{ "str" }
        82 objs |   ('a'..'z').to_a
```

1.9:

```
                |   100.times{ 1 }
                |   100.times{ 1 + 1 }
                |   100.times{ 1.1 }
       100 objs |   100.times{ 1.1 + 1 }
       100 objs |   100.times{ 1.1 + 1.1 }
       100 objs |   100.times{ "str" }
        30 objs |   ('a'..'z').to_a
```

2.0:

```
                |   100.times{ 1 }
                |   100.times{ 1 + 1 }
                |   100.times{ 1.1 }
                |   100.times{ 1.1 + 1 }
                |   100.times{ 1.1 + 1.1 }
       100 objs |   100.times{ "str" }
        29 objs |   ('a'..'z').to_a
```
