### PR TITLE
Threads

### DIFF
--- a/ext/rblineprof.c
+++ b/ext/rblineprof.c
@@ -100,9 +100,9 @@ struct stackinfo {
   #define MAX_STACK_DEPTH 32768
   stackframe_t stack[MAX_STACK_DEPTH];
   uint64_t stack_depth;
+  stackinfo_t *next;
 #ifdef RUBY_VM
   rb_thread_t *thread;
-  stackinfo_t *next;
 #endif
 };
 
@@ -404,8 +404,7 @@ profiler_hook(rb_event_flag_t event, NODE *node, VALUE self, ID mid, VALUE klass
 #endif
   };
 
-  stackinfo_t *current_stack;
-  current_stack = &rblineprof.stackinfo;
+  stackinfo_t *current_stack = &rblineprof.stackinfo;
 #ifdef RUBY_VM
   while (current_stack->thread != NULL && current_stack->thread != th) {
     if (current_stack->next == NULL) {
@@ -643,6 +642,7 @@ lineprof(VALUE self, VALUE filename)
   rblineprof.cache.srcfile = NULL;
   rblineprof.stackinfo.stack_depth = 0;
   cleanup_stack(rblineprof.stackinfo.next);
+  rblineprof.stackinfo.next = NULL;
 
   rblineprof.enabled = true;
 #ifndef RUBY_VM

--- a/ext/rblineprof.c
+++ b/ext/rblineprof.c
@@ -529,6 +529,7 @@ profiler_hook(rb_event_flag_t event, NODE *node, VALUE self, ID mid, VALUE klass
 #ifdef RUBY_VM
       if (th != rblineprof.last_thread) {
         offset = snapshot_diff(&rblineprof.last_snapshot, &current_stack->last_snapshot);
+        offset.wall_time = 0; // Wall time really happens, but CPU and allocations are on another thread.
       }
 #endif
       if (frame)

--- a/threadtest.rb
+++ b/threadtest.rb
@@ -25,7 +25,7 @@ def main
 end
 
 def getprofile
-  lineprof(File.expand_path(__FILE__)) do
+  lineprof(/threadtest/) do
     log(__LINE__) do
       t = Thread.new do
         log(__LINE__) do

--- a/threadtest.rb
+++ b/threadtest.rb
@@ -3,8 +3,7 @@ require 'rblineprof'
 $line_times = Hash.new(0.0)
 
 def main
-  profile = log(__LINE__) { getprofile }
-  profile = profile.values.first
+  profile = getprofile().values.first
   File.readlines(__FILE__).each_with_index do |content, i|
     lineno = i + 1
     line_time =
@@ -26,16 +25,18 @@ end
 
 def getprofile
   lineprof(File.expand_path(__FILE__)) do
-    t = Thread.new do
-      log(__LINE__) do
-        thread_work
+    log(__LINE__) do
+      t = Thread.new do
+        log(__LINE__) do
+          thread_work
+        end
       end
-    end
-    log(__LINE__) do
-      main_work
-    end
-    log(__LINE__) do
-      t.join
+      log(__LINE__) do
+        main_work
+      end
+      log(__LINE__) do
+        t.join
+      end
     end
   end
 end

--- a/threadtest.rb
+++ b/threadtest.rb
@@ -1,25 +1,40 @@
 require 'rblineprof'
 
+$line_times = Hash.new(0.0)
+
 def main
-  lines = File.readlines(__FILE__)
-  profile = log('total') { getprofile }
-  line_profs = profile[File.expand_path(__FILE__)].drop(1).take(lines.length)
-  line_profs.zip(lines).each do |(wall, cpu, calls, allocations), content|
-    printf "%8.1fms / %8.1fms (% 5d) (% 6d) | %s", wall/1000.0, cpu/1000.0, calls, allocations, content
+  profile = log(__LINE__) { getprofile }
+  profile = profile.values.first
+  File.readlines(__FILE__).each_with_index do |content, i|
+    lineno = i + 1
+    line_time =
+      if $line_times.has_key?(lineno)
+        sprintf('%6.3fms', $line_times[lineno] * 1000.0)
+      else
+        (' '*8)
+      end
+    prof_time =
+      if profile[lineno] && profile[lineno].any? { |x| x > 0 }
+        wall, cpu, _ = profile[lineno]
+        sprintf('%6.3fms (%6.3fms cpu)', wall / 1000.0, cpu / 1000.0)
+      else
+        ' '*23
+      end
+    puts "#{line_time} vs #{prof_time} | #{'%2d' % lineno} | #{content}"
   end
 end
 
 def getprofile
-  lineprof(/./) do
+  lineprof(File.expand_path(__FILE__)) do
     t = Thread.new do
-      log('thread') do
+      log(__LINE__) do
         thread_work
       end
     end
-    log('main') do
+    log(__LINE__) do
       main_work
     end
-    log('waitthread') do
+    log(__LINE__) do
       t.join
     end
   end
@@ -34,16 +49,15 @@ def main_work
 end
 
 def work(n)
-  log('sleep') { sleep 0.01          }
-  log('math')  { n.times { 2**1024 } }
+  log(__LINE__) { sleep 0.01          }
+  log(__LINE__) { n.times { 2**1024 } }
 end
 
-def log(label)
+def log(line)
   start = Time.now
   yield
 ensure
-  elapsed = Time.now - start
-  printf "%s: %.1fms\n", label, elapsed*1000.0
+  $line_times[line] += Time.now - start
 end
 
 main

--- a/threadtest.rb
+++ b/threadtest.rb
@@ -8,9 +8,9 @@ def main
     lineno = i + 1
     line_time =
       if $line_times.has_key?(lineno)
-        sprintf('%6.3fms', $line_times[lineno] * 1000.0)
+        sprintf('%6.3fms vs', $line_times[lineno] * 1000.0)
       else
-        (' '*8)
+        (' '*11)
       end
     prof_time =
       if profile[lineno] && profile[lineno].any? { |x| x > 0 }
@@ -19,7 +19,7 @@ def main
       else
         ' '*23
       end
-    puts "#{line_time} vs #{prof_time} | #{'%2d' % lineno} | #{content}"
+    puts "#{line_time} #{prof_time} | #{'%2d' % lineno} | #{content}"
   end
 end
 

--- a/threadtest.rb
+++ b/threadtest.rb
@@ -1,0 +1,49 @@
+require 'rblineprof'
+
+def main
+  lines = File.readlines(__FILE__)
+  profile = log('total') { getprofile }
+  line_profs = profile[File.expand_path(__FILE__)].drop(1).take(lines.length)
+  line_profs.zip(lines).each do |(wall, cpu, calls, allocations), content|
+    printf "%8.1fms / %8.1fms (% 5d) (% 6d) | %s", wall/1000.0, cpu/1000.0, calls, allocations, content
+  end
+end
+
+def getprofile
+  lineprof(/./) do
+    t = Thread.new do
+      log('thread') do
+        thread_work
+      end
+    end
+    log('main') do
+      main_work
+    end
+    log('waitthread') do
+      t.join
+    end
+  end
+end
+
+def thread_work
+  work(2000)
+end
+
+def main_work
+  work(3000)
+end
+
+def work(n)
+  sleep 0.01
+  n.times { 2**1024 }
+end
+
+def log(label)
+  start = Time.now
+  yield
+ensure
+  elapsed = Time.now - start
+  printf "%s: %.1fms\n", label, elapsed*1000.0
+end
+
+main

--- a/threadtest.rb
+++ b/threadtest.rb
@@ -34,8 +34,8 @@ def main_work
 end
 
 def work(n)
-  sleep 0.01
-  n.times { 2**1024 }
+  log('sleep') { sleep 0.01          }
+  log('math')  { n.times { 2**1024 } }
 end
 
 def log(label)

--- a/threadtest.rb
+++ b/threadtest.rb
@@ -1,3 +1,4 @@
+$:.unshift 'ext'
 require 'rblineprof'
 
 $line_times = Hash.new(0.0)


### PR DESCRIPTION
# Before

Note the difference between the simple timer and rblineprof on lines 30, 34, 37, 53.

```
$ ruby -I. -Iext threadtest.rb
...
                                    | 26 | def getprofile
                                    | 27 |   lineprof(File.expand_path(__FILE__)) do
24.073ms vs 24.084ms (10.712ms cpu) | 28 |     log(__LINE__) do
             0.037ms ( 0.012ms cpu) | 29 |       t = Thread.new do
23.902ms vs 18.350ms ( 6.386ms cpu) | 30 |         log(__LINE__) do
            18.327ms ( 6.372ms cpu) | 31 |           thread_work
                                    | 32 |         end
                                    | 33 |       end
18.380ms vs 24.004ms (10.671ms cpu) | 34 |       log(__LINE__) do
            23.957ms (10.659ms cpu) | 35 |         main_work
                                    | 36 |       end
 5.615ms vs  0.020ms ( 0.009ms cpu) | 37 |       log(__LINE__) do
                                    | 38 |         t.join
                                    | 39 |       end
                                    | 40 |     end
                                    | 41 |   end
                                    | 42 | end
                                    | 43 |
                                    | 44 | def thread_work
            18.325ms ( 6.371ms cpu) | 45 |   work(2000)
                                    | 46 | end
                                    | 47 |
                                    | 48 | def main_work
            23.941ms (10.649ms cpu) | 49 |   work(3000)
                                    | 50 | end
                                    | 51 |
                                    | 52 | def work(n)
28.532ms vs 34.103ms (10.721ms cpu) | 53 |   log(__LINE__) { sleep 0.01          }
13.634ms vs 13.667ms (10.501ms cpu) | 54 |   log(__LINE__) { n.times { 2**1024 } }
                                    | 55 | end
                                    | 56 |
                                    | 57 | def log(line)
             0.045ms ( 0.032ms cpu) | 58 |   start = Time.now
                                    | 59 |   yield
                                    | 60 | ensure
             0.192ms ( 0.109ms cpu) | 61 |   $line_times[line] += Time.now - start
                                    | 62 | end
                                    | 63 |
                                    | 64 | main
```

# After

The wall clock time is easy to verify with the manual timer. I think it's right.

I don't think the CPU time is right: I would expect line 37 to match line 38, and I would expect line 53 to be 0.

I haven't checked to see if allocations are correct.

```
$ ruby -I. -Iext threadtest.rb
...
                                    | 26 | def getprofile
                                    | 27 |   lineprof(File.expand_path(__FILE__)) do
25.985ms vs 26.010ms (11.988ms cpu) | 28 |     log(__LINE__) do
             0.029ms ( 0.010ms cpu) | 29 |       t = Thread.new do
24.719ms vs 25.835ms (11.904ms cpu) | 30 |         log(__LINE__) do
            24.711ms (11.504ms cpu) | 31 |           thread_work
                                    | 32 |         end
                                    | 33 |       end
19.789ms vs 19.804ms ( 7.225ms cpu) | 34 |       log(__LINE__) do
            19.783ms ( 7.213ms cpu) | 35 |         main_work
                                    | 36 |       end
 6.121ms vs  6.142ms ( 4.731ms cpu) | 37 |       log(__LINE__) do
             6.110ms ( 0.009ms cpu) | 38 |         t.join
                                    | 39 |       end
                                    | 40 |     end
                                    | 41 |   end
                                    | 42 | end
                                    | 43 |
                                    | 44 | def thread_work
            24.710ms (11.503ms cpu) | 45 |   work(2000)
                                    | 46 | end
                                    | 47 |
                                    | 48 | def main_work
            19.782ms ( 7.212ms cpu) | 49 |   work(3000)
                                    | 50 | end
                                    | 51 |
                                    | 52 | def work(n)
29.751ms vs 29.836ms ( 7.329ms cpu) | 53 |   log(__LINE__) { sleep 0.01          }
14.612ms vs 14.650ms (11.384ms cpu) | 54 |   log(__LINE__) { n.times { 2**1024 } }
                                    | 55 | end
                                    | 56 |
                                    | 57 | def log(line)
             0.049ms ( 0.029ms cpu) | 58 |   start = Time.now
                                    | 59 |   yield
                                    | 60 | ensure
             0.175ms ( 0.113ms cpu) | 61 |   $line_times[line] += Time.now - start
                                    | 62 | end
                                    | 63 |
                                    | 64 | main
```