### PR TITLE
`vm_core.h` may be a prereq for `iseq.h`

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -14,7 +14,7 @@ elsif RUBY_VERSION >= "1.9"
     have_type("rb_iseq_location_t", "vm_core.h")
 
     have_header("vm_core.h") and
-    have_header("iseq.h")
+    (have_header("iseq.h") or have_header("iseq.h", ["vm_core.h"]))
   }
 
   unless Debugger::RubyCoreSource::create_makefile_with_core(hdrs, "rblineprof")


### PR DESCRIPTION
@tmm1 - Same problem as https://github.com/tmm1/perftools.rb/pull/79 . This fixes rblineprof on OSX El Capitan. 